### PR TITLE
Prevents namespacing shadowed imported variables

### DIFF
--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -171,12 +171,12 @@ class Migrator extends BaseVisitor {
   void visitVariableExpression(VariableExpression node) {
     super.visitVariableExpression(node);
     if (_apis[currentPath].variables.containsKey(node.name)) return;
+    if (isLocalVariable(node.name)) return;
     var ns = findNamespaceFor(node.name, ApiType.variables);
     if (ns == null) {
       ns = makeImplicitDependencyExplicit(node.name, ApiType.variables);
       if (ns == null) return;
     }
-    // TODO(jathak): Confirm that this isn't a local variable before namespacing
     patches.add(Patch(node.span, "\$$ns.${node.name}"));
   }
 

--- a/test/migrations/simple_variables.hrx
+++ b/test/migrations/simple_variables.hrx
@@ -15,7 +15,9 @@ span {
 @import "three";
 $a: green;
 a {
+  $c: red;
   background: $b;
+  color: $c;
 }
 
 <==> input/three.scss
@@ -42,7 +44,9 @@ span {
 @use "three";
 $a: green;
 a {
+  $c: red;
   background: $three.b;
+  color: $c;
 }
 
 <==> expected/three.scss


### PR DESCRIPTION
When an imported variable is shadowed by a local variable, we should avoid namespacing it.