### PR TITLE
Basic support for namespacing get-function calls

### DIFF
--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -151,7 +151,7 @@ class _Migrator extends RecursiveStatementVisitor implements ExpressionVisitor {
         var beforeParen = node.span.end.offset - 1;
         _currentMigration.patches.add(Patch(
             node.span.file.span(beforeParen, beforeParen),
-            ", \$module: $namespace"));
+            ', \$module: "$namespace"'));
       });
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,6 @@ dependencies:
   path: "^1.6.0"
 
 dev_dependencies:
+  term_glyph: "^1.1.0"
   test: ">=0.12.29 <2.0.0"
   test_descriptor: "^1.1.1"

--- a/test/migrations/README.md
+++ b/test/migrations/README.md
@@ -16,3 +16,6 @@ The migrator will run starting from these entrypoints.
 For each file in `input` that would be modified by this migration, there should
 be a corresponding file in `output` with the migrated contents. `output` should
 not contain a file if it would not be changed by the migrator.
+
+If any warnings should be emitted by this migration, there should be an
+additional file called `log.txt` that contains the expected printed text.

--- a/test/migrations/namespace_get_function.hrx
+++ b/test/migrations/namespace_get_function.hrx
@@ -1,37 +1,47 @@
 <==> input/entrypoint.scss
 @import "library";
+@import "true";
 
 $fn1: get-function(increment);
-$fn2: get-function($name: "increment");
-$fn3: get-function("incre" + "ment");
+$fn2: get-function($name: "false");
+$fn3: get-function("str-length");
+$fn4: get-function("incre" + "ment");
 
 $x: "increment";
-$fn4: get-function($x);
+$fn5: get-function($x);
 
 <==> input/_library.scss
 @function increment($x) {
   @return $x + 1;
 }
 
+<==> input/_true.scss
+@function false($x) {
+  @return not $x;
+}
+
 <==> output/entrypoint.scss
 @use "sass:meta";
+@use "sass:string";
 @use "library";
+@use "true";
 
-$fn1: meta.get-function(increment, $module: library);
-$fn2: meta.get-function($name: "increment", $module: library);
-$fn3: meta.get-function("incre" + "ment");
+$fn1: meta.get-function(increment, $module: "library");
+$fn2: meta.get-function($name: "false", $module: "true");
+$fn3: meta.get-function("length", $module: "string");
+$fn4: meta.get-function("incre" + "ment");
 
 $x: "increment";
-$fn4: meta.get-function($x);
+$fn5: meta.get-function($x);
 
 <==> log.txt
-line 5, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+line 7, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
   ,
-5 | $fn3: get-function("incre" + "ment");
+7 | $fn4: get-function("incre" + "ment");
   |                    ^^^^^^^^^^^^^^^^
   '
-line 8, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+line 10, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
   ,
-8 | $fn4: get-function($x);
+10| $fn5: get-function($x);
   |                    ^^
   '

--- a/test/migrations/namespace_get_function.hrx
+++ b/test/migrations/namespace_get_function.hrx
@@ -1,0 +1,39 @@
+<==> input/entrypoint.scss
+@import "library";
+
+$fn1: get-function(increment);
+$fn2: get-function($name: "increment");
+$fn3: get-function("incre" + "ment");
+
+$x: "increment";
+$fn4: get-function($x);
+
+<==> input/_library.scss
+@function increment($x) {
+  @return $x + 1;
+}
+
+<==> output/entrypoint.scss
+@use "sass:meta";
+@use "library";
+
+$fn1: meta.get-function(library.increment);
+$fn2: meta.get-function($name: "library.increment");
+$fn3: meta.get-function("incre" + "ment");
+
+$x: "increment";
+$fn4: meta.get-function($x);
+
+<==> log.txt
+WARNING: Could not determine if namespace is required for get-function call @
+  ╷
+5 │ $fn3: get-function("incre" + "ment");
+  │                    ^^^^^^^^^^^^^^^^
+  ╵
+  $TEST_DIR/entrypoint.scss
+WARNING: Could not determine if namespace is required for get-function call @
+  ╷
+8 │ $fn4: get-function($x);
+  │                    ^^
+  ╵
+  $TEST_DIR/entrypoint.scss

--- a/test/migrations/namespace_get_function.hrx
+++ b/test/migrations/namespace_get_function.hrx
@@ -17,23 +17,21 @@ $fn4: get-function($x);
 @use "sass:meta";
 @use "library";
 
-$fn1: meta.get-function(library.increment);
-$fn2: meta.get-function($name: "library.increment");
+$fn1: meta.get-function(increment, $module: library);
+$fn2: meta.get-function($name: "increment", $module: library);
 $fn3: meta.get-function("incre" + "ment");
 
 $x: "increment";
 $fn4: meta.get-function($x);
 
 <==> log.txt
-WARNING: Could not determine if namespace is required for get-function call @
-  ╷
-5 │ $fn3: get-function("incre" + "ment");
-  │                    ^^^^^^^^^^^^^^^^
-  ╵
-  $TEST_DIR/entrypoint.scss
-WARNING: Could not determine if namespace is required for get-function call @
-  ╷
-8 │ $fn4: get-function($x);
-  │                    ^^
-  ╵
-  $TEST_DIR/entrypoint.scss
+line 5, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+  ,
+5 | $fn3: get-function("incre" + "ment");
+  |                    ^^^^^^^^^^^^^^^^
+  '
+line 8, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+  ,
+8 | $fn4: get-function($x);
+  |                    ^^
+  '

--- a/test/migrations/namespace_get_function.hrx
+++ b/test/migrations/namespace_get_function.hrx
@@ -3,6 +3,8 @@
 @import "true";
 
 $fn1: get-function(increment);
+// This function's namespace is `true`, which is a boolean when unquoted.
+// This tests that the $module parameter is a quoted string.
 $fn2: get-function($name: "false");
 $fn3: get-function("str-length");
 $fn4: get-function("incre" + "ment");
@@ -27,6 +29,8 @@ $fn5: get-function($x);
 @use "true";
 
 $fn1: meta.get-function(increment, $module: "library");
+// This function's namespace is `true`, which is a boolean when unquoted.
+// This tests that the $module parameter is a quoted string.
 $fn2: meta.get-function($name: "false", $module: "true");
 $fn3: meta.get-function("length", $module: "string");
 $fn4: meta.get-function("incre" + "ment");
@@ -35,13 +39,13 @@ $x: "increment";
 $fn5: meta.get-function($x);
 
 <==> log.txt
-line 7, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+line 9, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
   ,
-7 | $fn4: get-function("incre" + "ment");
+9 | $fn4: get-function("incre" + "ment");
   |                    ^^^^^^^^^^^^^^^^
   '
-line 10, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
-  ,
-10| $fn5: get-function($x);
-  |                    ^^
-  '
+line 12, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+   ,
+12 | $fn5: get-function($x);
+   |                    ^^
+   '

--- a/test/migrator_test.dart
+++ b/test/migrator_test.dart
@@ -9,11 +9,13 @@ import 'dart:io';
 import 'package:sass_module_migrator/src/migrator.dart';
 
 import 'package:path/path.dart' as p;
+import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 /// Runs all migration tests. See migrations/README.md for details.
 void main() {
+  glyph.ascii = true;
   var migrationTests = Directory("test/migrations");
   for (var file in migrationTests.listSync().whereType<File>()) {
     if (file.path.endsWith(".hrx")) {

--- a/test/migrator_test.dart
+++ b/test/migrator_test.dart
@@ -28,7 +28,12 @@ testHrx(File hrxFile) async {
   await files.unpack();
   var entrypoints =
       files.input.keys.where((path) => path.startsWith("entrypoint"));
-  var migrated = migrateFiles(entrypoints, directory: d.sandbox);
+  p.PathMap<String> migrated;
+  var migration = () {
+    migrated = migrateFiles(entrypoints, directory: d.sandbox);
+  };
+  expect(migration,
+      prints(files.expectedLog?.replaceAll("\$TEST_DIR", d.sandbox) ?? ""));
   for (var file in files.input.keys) {
     expect(migrated[p.join(d.sandbox, file)], equals(files.output[file]),
         reason: 'Incorrect migration of $file.');
@@ -38,6 +43,7 @@ testHrx(File hrxFile) async {
 class HrxTestFiles {
   Map<String, String> input = {};
   Map<String, String> output = {};
+  String expectedLog;
 
   HrxTestFiles(String hrxText) {
     // TODO(jathak): Replace this with an actual HRX parser.
@@ -62,6 +68,8 @@ class HrxTestFiles {
       input[filename.substring(6)] = contents;
     } else if (filename.startsWith("output/")) {
       output[filename.substring(7)] = contents;
+    } else if (filename == "log.txt") {
+      expectedLog = contents;
     }
   }
 


### PR DESCRIPTION
Resolves #11.

If the argument passed to get-function is a string literal, we'll add a namespace if necessary.

For all other `get-function` calls, we'll emit a warning saying that a namespace may be required. We might eventually be able to detect some of these with some more sophisticated logic here, but for now we'll just handle the basics.